### PR TITLE
Branch length output for incorrectly detected outgroup

### DIFF
--- a/src/corpus_distance/clusterisation/utils.py
+++ b/src/corpus_distance/clusterisation/utils.py
@@ -53,15 +53,15 @@ def detect_outgroup(tree: Phylo.BaseTree.Tree, outgroup: str, data_name: str,
         raise ValueError("Directory not exists")
     if tree.rooted is False:
         raise ValueError("Tree is unrooted, not possible to detect outgroup")
-    if (outgroup in [tree.clade.clades[0].name, tree.clade.clades[1].name]):
-        outgroup_clade = 0 if tree.clade.clades[0].name == outgroup else 1
-        ingroup_clade = 1 if tree.clade.clades[0].name == outgroup else 0
-        with open(join(store_path, metrics + ".info"), 'w', encoding='utf-8') as out:
-            out.write(f"{data_name}\tCORRECT\t{tree.clade.clades[outgroup_clade].branch_length}\t\
-                      {tree.clade.clades[ingroup_clade].branch_length}")
-    else:
-        with open(join(store_path, metrics + ".info"), 'w', encoding='utf-8') as out:
-            out.write(f"{data_name}\tINCORRECT\tNA\tNA")
+    is_outgroup_correct = 'CORRECT'\
+        if outgroup in [tree.clade.clades[0].name, tree.clade.clades[1].name]\
+        else 'INCORRECT'
+    outgroup_clade = 0 if tree.clade.clades[0].is_terminal() else 1
+    ingroup_clade = 1 if tree.clade.clades[0].is_terminal() == outgroup else 0
+    with open(join(store_path, metrics + ".info"), 'w', encoding='utf-8') as out:
+        out.write(f"{data_name}\t{is_outgroup_correct}\t\
+                  {tree.clade.clades[outgroup_clade].branch_length}\t\
+                    {tree.clade.clades[ingroup_clade].branch_length}")
     Phylo.write(tree, join(store_path, metrics + ".newick"), 'newick')
 
 


### PR DESCRIPTION
Previously for trees with incorrectly detected outgroups there was no information on branch lengths. Now it is fixed.